### PR TITLE
add in a logging NullHandler

### DIFF
--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -8,8 +8,12 @@ import logging
 import os
 import socket
 
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
 LOG = logging.getLogger(__name__)
-LOG.addHandler(logging.NullHandler())
+LOG.addHandler(NullHandler())
 
 
 def _consume_request(environ):


### PR DESCRIPTION
Firstly, thanks for the module. This was exactly what I was looking for. However, we're stuck deploying to RHEL6 which ships with python 2.6, and thus I needed to make a small change for compatibility.

Simply, logging.NullHandler was added in python 2.7.

I've added a local NullHandler definition which comes from the documentation at:

https://docs.python.org/2.6/library/logging.html#configuring-logging-for-a-library
