### PR TITLE
Fix overly restrictive usage of authGSSServerInit

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Michael Komitee
+Joshua Bronson


### PR DESCRIPTION
Drop hostname and service, to no longer needlessly limit to those passed at initialization time.