### PR TITLE
Swallow KrbError, not just GSSError. Fixes #7.

### DIFF
--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -156,7 +156,7 @@ class KerberosAuthMiddleware(object):
                     user = kerberos.authGSSServerUserName(state)
                 elif rc == kerberos.AUTH_GSS_CONTINUE:
                     server_token = kerberos.authGSSServerResponse(state)
-        except kerberos.GSSError:
+        except kerberos.KrbError:
             pass
         finally:
             if state:


### PR DESCRIPTION
`except GSSError` is too narrow to catch the `KrbError` that is raised e.g. in the case that a `client_token` of empty string is provided, so broaden the `except` to catch `KrbError` (which is the [base class](https://github.com/apple/ccs-pykerberos/blob/133299a9446a78b07eb7b337269507972f6e12ef/pysrc/kerberos.py#L23) of all kerberos exceptions).