### PR TITLE
Improve reporting of unhandled errors.

### DIFF
--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -159,8 +159,8 @@ class KerberosAuthMiddleware(object):
                     user = kerberos.authGSSServerUserName(state)
                 elif rc == kerberos.AUTH_GSS_CONTINUE:
                     server_token = kerberos.authGSSServerResponse(state)
-        except kerberos.KrbError:
-            pass
+        except kerberos.GSSError as exc:
+            LOG.error("Unhandled GSSError: %s", exc)
         finally:
             if state:
                 kerberos.authGSSServerClean(state)


### PR DESCRIPTION
- Log (rather than swallow) unhandled Kerberos errors.

UPDATE: removed in latest revision:

- ~Allow supplying custom 401 and 403 response bodies per call.~ 

- ~When there is an unhandled Kerberos error, send it in the body of the 403 response using the new support for custom bodies per call.~

This significantly improves debuggability when GSS API calls fail for some reason.