### PR TITLE
Always set REMOTE_USER when valid auth provided (even if not required).

### DIFF
--- a/test_wsgi_kerberos.py
+++ b/test_wsgi_kerberos.py
@@ -57,6 +57,22 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
 
+    def test_unauthorized_when_missing_negotiate(self):
+        '''
+        Ensure that when the client sends an Authorization header that does
+        not start with "Negotiate ", they receive a 401 Unauthorized response
+        with a "WWW-Authenticate: Negotiate" header.
+        '''
+        app = TestApp(KerberosAuthMiddleware(index))
+
+        r = app.get('/', headers={'Authorization': 'foo'}, expect_errors=True)
+
+        self.assertEqual(r.status, '401 Unauthorized')
+        self.assertEqual(r.status_int, 401)
+        self.assertTrue(r.body.startswith(b'Unauthorized'))
+        self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
+        self.assertEqual(r.headers['content-type'], 'text/plain')
+
     def test_unauthorized_custom(self):
         '''
         Ensure that when the client does not send an authorization token, they

--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -77,7 +77,7 @@ class KerberosAuthMiddleware(object):
     :param forbidden: 403 Response text or text/content-type tuple
     :type forbidden: str or tuple
     :param auth_required_callback: predicate accepting the WSGI environ
-        for a request returning whether the request should be authenticated 
+        for a request returning whether the request should be authenticated
     :type auth_required_callback: callable
     '''
 
@@ -182,9 +182,12 @@ class KerberosAuthMiddleware(object):
         if authorization is None:
             return self._unauthorized(environ, start_response)
 
-        # If we have an 'Authorization' header, extract the client's token and
-        # attempt to authenticate with it.
-        client_token = ''.join(authorization.split()[1:])
+        # We have an 'Authorization' header -> should start with 'Negotiate '.
+        parsed = authorization.split(None, 1)
+        if len(parsed) < 2 or parsed[0].lower() != 'negotiate':
+            return self._unauthorized(environ, start_response)
+        # Extract the client's token and attempt to authenticate with it.
+        client_token = parsed[1]
         server_token, user = self._authenticate(client_token)
 
         # If we get a server_token and a user, call the application, add our

--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -172,20 +172,28 @@ class KerberosAuthMiddleware(object):
         Include a token in the response headers that can be used to
         authenticate the server to the client.
         '''
-        # If we don't need to authenticate the request, shortcut the whole
-        # process.
-        if not self.auth_required_callback(environ):
+        # If we don't need to authenticate the request, don't immediately
+        # bypass authentication, but rather just remember this for now.
+        # This way, if auth is not required, but the client provides valid
+        # auth anyway, we still tell the application who made the request.
+        auth_required = self.auth_required_callback(environ)
+
+        def _40x_resp_if_auth_required(error_resp, **kw):
+            if auth_required:
+                return error_resp(environ, start_response, **kw)
             return self.application(environ, start_response)
 
         authorization = environ.get('HTTP_AUTHORIZATION')
-        # If we have no 'Authorization' header, return a 401.
+        # If we have no 'Authorization' header...
         if authorization is None:
-            return self._unauthorized(environ, start_response)
+            return _40x_resp_if_auth_required(self._unauthorized)
 
-        # We have an 'Authorization' header -> should start with 'Negotiate '.
+        # We have an Authorization header -> should start with "negotiate".
         parsed = authorization.split(None, 1)
         if len(parsed) < 2 or parsed[0].lower() != 'negotiate':
-            return self._unauthorized(environ, start_response)
+            LOG.debug("Authorization header did not start with 'negotiate'")
+            return _40x_resp_if_auth_required(self._unauthorized)
+
         # Extract the client's token and attempt to authenticate with it.
         client_token = parsed[1]
         server_token, user = self._authenticate(client_token)
@@ -205,7 +213,8 @@ class KerberosAuthMiddleware(object):
             return self.application(environ, custom_start_response)
         elif server_token:
             # If we got a token, but no user, return a 401 with the token
-            return self._unauthorized(environ, start_response, server_token)
+            return _40x_resp_if_auth_required(
+                self._unauthorized, token=server_token)
         else:
             # Otherwise, return a 403.
-            return self._forbidden(environ, start_response)
+            return _40x_resp_if_auth_required(self._forbidden)


### PR DESCRIPTION
Interpret "auth not required" (i.e. `auth_required_callback` returning False)
to mean: missing/invalid auth will not result in a 40x error,
but if a client does provide valid auth for an auth-not-required request,
the remote user will be exposed to the app, since it can still be useful to know .

This better supports cases where auth is not required for a particular request
(e.g. a health check endpoint hit anonymously by Kubernetes),
but it is still useful to know who made the request when valid auth is provided
(e.g. a script or user interactively hitting the health check endpoint
from a client that does pre-emptive Kerberos -- in this case the app
can check if the remote user is an admin, and display richer info
in the health check response body).

Includes unit tests ~and also updates the "Changes" section of the README~ (UPDATE: removed release notes changes originally added to the README, as requested in a different PR).