### PR TITLE
Drop "consume request on 401" behavior.

### DIFF
--- a/test_wsgi_kerberos.py
+++ b/test_wsgi_kerberos.py
@@ -1,4 +1,4 @@
-from wsgi_kerberos import KerberosAuthMiddleware, ensure_bytestring, _DEFAULT_READ_MAX
+from wsgi_kerberos import KerberosAuthMiddleware, ensure_bytestring
 from webtest import TestApp, TestRequest
 import kerberos
 import mock
@@ -119,23 +119,6 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Unauthorized')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-
-    def test_read_max_on_auth_fail(self):
-        '''
-        KerberosAuthMiddleware's ``read_max_on_auth_fail`` should allow
-        customizing reading of request bodies of unauthenticated requests.
-        '''
-        body = b'body of unauthenticated request'
-        for read_max in (0, 5, 100, _DEFAULT_READ_MAX, float('inf')):
-            # When we drop Py2, we can use `with self.subTest(read_max=read_max):` here.
-            app = TestApp(KerberosAuthMiddleware(index, read_max_on_auth_fail=read_max))
-            req = TestRequest.blank('/', method='POST', body=body)
-            resp = app.do_request(req, status=401)
-            if read_max < len(body):
-                expect_read = 0
-            else:
-                expect_read = min(read_max, len(body))
-            self.assertEqual(req.body_file.input.tell(), expect_read)
 
     def test_unauthorized_when_missing_negotiate(self):
         '''


### PR DESCRIPTION
Resolves #11, #12, #27.

Production-quality WSGI servers such as Gunicorn and uWSGI handle this already. WSGI-Kerberos trying to handle it at the WSGI middleware layer defeats the safer and more robust handling that otherwise comes out-of-the-box in production quality WSGI servers.

The consume request behavior was probably originally added to WSGI-Kerberos when testing with a non-production-quality WSGI server, not realizing that simply using a production-quality WSGI server would have made clients' connection issues disappear, and in a safer and more efficient and performant way. /cc @mkomitee

Submitting this as a new PR based on discussion in [#27](https://github.com/deshaw/wsgi-kerberos/pull/28#discussion_r556942581) (after originally submitting this in #25; GitHub isn't letting me reopen #25 for some reason).

Having WSGI-Kerberos immediately send 401 responses without first waiting to drain the request socket for potentially naive clients allows production-quality WSGI servers (or even an upstream proxy like NGINX) to immediately see the 401, and then take responsibility for draining the request socket in a safe way before forwarding the 401 to the client.