### PR TITLE
Ensure we send a content length on our 401 / 403 responses

### DIFF
--- a/test_wsgi_kerberos.py
+++ b/test_wsgi_kerberos.py
@@ -31,7 +31,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '15')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [])
         self.assertEqual(step.mock_calls, [])
@@ -64,7 +64,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '15')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -98,7 +98,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers.get('WWW-Authenticate'), 'negotiate STOKEN')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '22')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -122,7 +122,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Unauthorized')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '12')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
     def test_read_max_on_auth_fail(self):
         '''
@@ -156,7 +156,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertTrue(r.body.startswith(b'Unauthorized'))
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '12')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
     def test_unauthorized_custom(self):
         '''
@@ -175,7 +175,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '6')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
     def test_unauthorized_custom_content_type(self):
         '''
@@ -194,7 +194,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'401!')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/html')
-        self.assertEqual(r.headers['content-length'], '4')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
     @mock.patch('kerberos.authGSSServerInit')
     @mock.patch('kerberos.authGSSServerStep')
@@ -221,7 +221,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers['WWW-Authenticate'], 'negotiate STOKEN')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '22')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -252,7 +252,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'Forbidden')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '9')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -284,7 +284,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], '6')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -316,7 +316,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['content-type'], 'text/html')
-        self.assertEqual(r.headers['content-length'], '6')
+        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])

--- a/test_wsgi_kerberos.py
+++ b/test_wsgi_kerberos.py
@@ -30,8 +30,6 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
-        self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [])
         self.assertEqual(step.mock_calls, [])
@@ -63,8 +61,6 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
-        self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -97,8 +93,6 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers.get('WWW-Authenticate'), 'negotiate STOKEN')
-        self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -220,8 +214,6 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 200)
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers['WWW-Authenticate'], 'negotiate STOKEN')
-        self.assertEqual(r.headers['content-type'], 'text/plain')
-        self.assertEqual(r.headers['content-length'], str(len(r.body)))
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])

--- a/test_wsgi_kerberos.py
+++ b/test_wsgi_kerberos.py
@@ -31,6 +31,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '15')
 
         self.assertEqual(init.mock_calls, [])
         self.assertEqual(step.mock_calls, [])
@@ -63,6 +64,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello ANONYMOUS')
         self.assertEqual(r.headers.get('WWW-Authenticate'), None)
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '15')
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -96,6 +98,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers.get('WWW-Authenticate'), 'negotiate STOKEN')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '22')
 
         self.assertEqual(init.mock_calls, [mock.call('HTTP@example.org')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -119,6 +122,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Unauthorized')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '12')
 
     def test_read_max_on_auth_fail(self):
         '''
@@ -152,6 +156,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertTrue(r.body.startswith(b'Unauthorized'))
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '12')
 
     def test_unauthorized_custom(self):
         '''
@@ -170,6 +175,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '6')
 
     def test_unauthorized_custom_content_type(self):
         '''
@@ -188,6 +194,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'401!')
         self.assertEqual(r.headers['www-authenticate'], 'Negotiate')
         self.assertEqual(r.headers['content-type'], 'text/html')
+        self.assertEqual(r.headers['content-length'], '4')
 
     @mock.patch('kerberos.authGSSServerInit')
     @mock.patch('kerberos.authGSSServerStep')
@@ -214,6 +221,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.body, b'Hello user@EXAMPLE.ORG')
         self.assertEqual(r.headers['WWW-Authenticate'], 'negotiate STOKEN')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '22')
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -244,6 +252,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'Forbidden')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '9')
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -275,6 +284,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['content-type'], 'text/plain')
+        self.assertEqual(r.headers['content-length'], '6')
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])
@@ -306,6 +316,7 @@ class BasicAppTestCase(unittest.TestCase):
         self.assertEqual(r.status_int, 403)
         self.assertEqual(r.body, b'CUSTOM')
         self.assertEqual(r.headers['content-type'], 'text/html')
+        self.assertEqual(r.headers['content-length'], '6')
 
         self.assertEqual(init.mock_calls, [mock.call('')])
         self.assertEqual(step.mock_calls, [mock.call(state, 'CTOKEN')])

--- a/wsgi_kerberos.py
+++ b/wsgi_kerberos.py
@@ -169,7 +169,10 @@ class KerberosAuthMiddleware(object):
         '''
         Send a 401 Unauthorized response
         '''
-        headers = [('content-type', self.unauthorized[1])]
+        headers = [
+            ('content-type', self.unauthorized[1]),
+            ('content-length', str(len(self.unauthorized[0])))
+        ]
         if token:
             headers.append(('WWW-Authenticate', token))
         else:
@@ -182,7 +185,10 @@ class KerberosAuthMiddleware(object):
         '''
         Send a 403 Forbidden response
         '''
-        headers = [('content-type', self.forbidden[1])]
+        headers = [
+            ('content-type', self.forbidden[1]),
+            ('content-length', str(len(self.forbidden[0])))
+        ]
         _consume_request(environ, self.read_max_on_auth_fail)
         start_response('403 Forbidden', headers)
         return [self.forbidden[0]]


### PR DESCRIPTION
We should be setting a content length on the responses we generate for auth purposes. While some wsgi servers automatically add it themselves (e.g. `wsgiref.simple_server`), not all do (e.g. `uwsgi`), and this has been known to cause issues with some clients.